### PR TITLE
config: add post-cmd-executor pool size

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,6 +10,9 @@ builds:
     main: ./src/cmd/olive
     env:
       - CGO_ENABLED=0
+      
+    ldflags:
+      - -s -w -X github.com/go-olive/olive/src/config.AppVersion={{.Tag}}
 
     goos:
       - linux

--- a/src/app/device.go
+++ b/src/app/device.go
@@ -31,6 +31,8 @@ func NewDevice() IDevice {
 }
 
 func (d *device) Run() {
+	l.Logger.Infof("Powered by go-olive/olive %s", config.AppVersion)
+
 	for _, v := range config.APP.Shows {
 		s, err := engine.NewShow(v.Platform, v.RoomID,
 			engine.WithStreamerName(v.StreamerName),

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"flag"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 )
 
 var (
+	AppVersion string
 	APP        *appConfig
 	defaultAPP = appConfig{}
 )
@@ -63,18 +65,31 @@ type PlatformConfig struct {
 }
 
 func init() {
-	path, err := os.Getwd()
-	if err != nil {
-		l.Logger.Fatal(err)
-	}
-	appCfgFilePath := filepath.Join(path, "config.toml")
-
-	flag.StringVar(&appCfgFilePath, "c", appCfgFilePath, "config.toml配置文件存放路径")
+	var (
+		appCfgFilePath string
+		version        bool
+	)
+	flag.BoolVar(&version, "v", version, "print olive version")
+	flag.StringVar(&appCfgFilePath, "c", appCfgFilePath, "set config.toml filepath")
 	flag.Parse()
 
+	if version {
+		fmt.Println(AppVersion)
+		os.Exit(0)
+	}
+
+	var Usage = func() {
+		fmt.Printf("Powered by go-olive/olive %s\n", AppVersion)
+		fmt.Println("Usage:")
+		flag.PrintDefaults()
+	}
+	if appCfgFilePath == "" {
+		Usage()
+		os.Exit(0)
+	}
+
 	viper.SetConfigFile(appCfgFilePath)
-	err = viper.ReadInConfig()
-	if err != nil {
+	if err := viper.ReadInConfig(); err != nil {
 		l.Logger.WithField("err", err.Error()).
 			Fatal("load config file failed")
 	}

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -21,12 +21,25 @@ var (
 )
 
 type appConfig struct {
-	LogLevel        logrus.Level
-	SnapRestSeconds uint32
+	LogLevel          logrus.Level
+	SnapRestSeconds   uint
+	CommanderPoolSize uint
 
 	*UploadConfig
 	*PlatformConfig
 	Shows []*Show
+}
+
+func (this *appConfig) checkAndFix() {
+	if this.LogLevel == 0 {
+		this.LogLevel = logrus.DebugLevel
+	}
+	if this.SnapRestSeconds == 0 {
+		this.SnapRestSeconds = 15
+	}
+	if this.CommanderPoolSize == 0 {
+		this.CommanderPoolSize = 1
+	}
 }
 
 type Show struct {
@@ -108,6 +121,8 @@ func verify() {
 		l.Logger.Info("use default APP config")
 		APP = &defaultAPP
 	}
+	APP.checkAndFix()
+
 	l.Logger.SetLevel(APP.LogLevel)
 
 	if APP.UploadConfig == nil {

--- a/src/uploader/uploader.worker_pool.go
+++ b/src/uploader/uploader.worker_pool.go
@@ -8,7 +8,7 @@ import (
 	l "github.com/go-olive/olive/src/log"
 )
 
-var UploaderWorkerPool = NewWorkerPool(1)
+var UploaderWorkerPool = NewWorkerPool(config.APP.CommanderPoolSize)
 
 func init() {
 	if !config.APP.UploadConfig.Enable {


### PR DESCRIPTION
```toml
CommanderPoolSize = 1
```

can manually set how many workers execute post-cmd concurrently