### PR TITLE
config: add post-cmd-executor pool size

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -19,12 +19,25 @@ var (
 )
 
 type appConfig struct {
-	LogLevel        logrus.Level
-	SnapRestSeconds uint32
+	LogLevel          logrus.Level
+	SnapRestSeconds   uint
+	CommanderPoolSize uint
 
 	*UploadConfig
 	*PlatformConfig
 	Shows []*Show
+}
+
+func (this *appConfig) checkAndFix() {
+	if this.LogLevel == 0 {
+		this.LogLevel = logrus.DebugLevel
+	}
+	if this.SnapRestSeconds == 0 {
+		this.SnapRestSeconds = 15
+	}
+	if this.CommanderPoolSize == 0 {
+		this.CommanderPoolSize = 1
+	}
 }
 
 type Show struct {
@@ -93,6 +106,8 @@ func verify() {
 		l.Logger.Info("use default APP config")
 		APP = &defaultAPP
 	}
+	APP.checkAndFix()
+
 	l.Logger.SetLevel(APP.LogLevel)
 
 	if APP.UploadConfig == nil {

--- a/src/uploader/uploader.worker_pool.go
+++ b/src/uploader/uploader.worker_pool.go
@@ -8,7 +8,7 @@ import (
 	l "github.com/go-olive/olive/src/log"
 )
 
-var UploaderWorkerPool = NewWorkerPool(1)
+var UploaderWorkerPool = NewWorkerPool(config.APP.CommanderPoolSize)
 
 func init() {
 	if !config.APP.UploadConfig.Enable {


### PR DESCRIPTION
```toml
CommanderPoolSize = 1
```

can manually set how many workers execute post-cmd concurrently