### PR TITLE
streamlink和ffmpeg改为输出 mp4

### DIFF
--- a/engine/parser/ffmpeg.go
+++ b/engine/parser/ffmpeg.go
@@ -60,7 +60,7 @@ func (p *ffmpeg) Parse(streamURL string, out string) (err error) {
 		"-i", streamURL,
 		"-c", "copy",
 		"-bsf:a", "aac_adtstoasc",
-		"-f", "flv",
+		//"-f", "flv",
 		out,
 	)
 	// p.cmd.Stderr = os.Stderr

--- a/engine/recorder/recorder.go
+++ b/engine/recorder/recorder.go
@@ -164,6 +164,12 @@ func (r *recorder) record() error {
 	out = filepath.Join(saveDir, out)
 
 	switch r.parser.Type() {
+	case "streamlink":
+		ext := filepath.Ext(out)
+		out = out[0:len(out)-len(ext)] + ".mp4"
+	case "ffmpeg":
+		ext := filepath.Ext(out)
+		out = out[0:len(out)-len(ext)] + ".mp4"
 	case "yt-dlp":
 		ext := filepath.Ext(out)
 		out = out[0:len(out)-len(ext)] + ".mp4"


### PR DESCRIPTION
- 修改 streamlink和ffmpeg改为输出 mp4 。
- streamlink不管参数改成什么格式，默认输出mp4，所以只是最后生成文件名区别。
- ffmpeg 格式不同生成对应格式文件。
- 相对于flv格式mp4默认提供预览和定位。